### PR TITLE
feat: add services to reset and tare device

### DIFF
--- a/include/vectornav/vectornav.hpp
+++ b/include/vectornav/vectornav.hpp
@@ -87,6 +87,8 @@ private:
   // Services
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_set_acc_bias_{ nullptr };
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_reset_acc_bias_{ nullptr };
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_reset_device_{ nullptr };
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr srv_tare_device_{ nullptr };
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr srv_reset_odom_{ nullptr };
 
   void read_parameters();
@@ -110,6 +112,12 @@ private:
   void reset_odometry(
     const std::shared_ptr<std_srvs::srv::Empty::Request> req,
     std::shared_ptr<std_srvs::srv::Empty::Response> resp);
+  void reset_device(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
+  void tare_device(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
   
   static void binary_async_message_received(void* ,vn::protocol::uart::Packet & p, size_t index);
   void binary_async_message_received_(vn::protocol::uart::Packet & p, size_t index);

--- a/include/vectornav/vectornav_lifecycle.hpp
+++ b/include/vectornav/vectornav_lifecycle.hpp
@@ -95,6 +95,8 @@ private:
   // Services
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr
     srv_set_acc_bias_{ nullptr }, srv_reset_acc_bias_{ nullptr };
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr
+    srv_reset_device_{ nullptr }, srv_tare_device_{ nullptr };
   rclcpp::Service<std_srvs::srv::Empty>::SharedPtr
     srv_reset_odom_{ nullptr };
 
@@ -118,6 +120,12 @@ private:
     const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
     std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
   void reset_acc_bias(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
+  void reset_device(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
+  void tare_device(
     const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
     std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
   void reset_odometry(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ rclcpp::Publisher<sensor_msgs::msg::FluidPressure>::SharedPtr pubPres;
 rclcpp::Publisher<vectornav::msg::Ins>::SharedPtr pubIns;
 
 rclcpp::Service<std_srvs::srv::Empty>::SharedPtr resetOdomSrv;
-rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr setHorizontalSrv, resetHorizontalSrv;
+rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr setHorizontalSrv, resetHorizontalSrv, resetDeviceSrv, tareDeviceSrv;
 
 //XmlRpc::XmlRpcValue rpc_temp;
 
@@ -161,6 +161,32 @@ void reset_horizontal(const std::shared_ptr<std_srvs::srv::Trigger::Request> req
 
   resp->success = true;
   resp->message = "Bias register set to zero. Please, reset vectornav hardware to avoid angular velocity.";
+  RCLCPP_INFO(node->get_logger(), "Done.");
+}
+
+void reset_device(const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp, VnSensor* vs_ptr)
+{
+  std::unique_lock<std::mutex> service_lock(service_acc_bias_mtx);
+  RCLCPP_INFO(node->get_logger(), "Reset vectornav device");
+
+  vs_ptr->reset();
+
+  resp->success = true;
+  resp->message = "Device reset command sent.";
+  RCLCPP_INFO(node->get_logger(), "Done.");
+}
+
+void tare_device(const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp, VnSensor* vs_ptr)
+{
+  std::unique_lock<std::mutex> service_lock(service_acc_bias_mtx);
+  RCLCPP_INFO(node->get_logger(), "Tare vectornav device (zero angular velocity and acceleration)");
+
+  vs_ptr->tare();
+
+  resp->success = true;
+  resp->message = "Device tare command sent.";
   RCLCPP_INFO(node->get_logger(), "Done.");
 }
 
@@ -512,6 +538,10 @@ int main(int argc, char * argv[])
       "~/set_acc_bias", std::bind(set_horizontal, std::placeholders::_1, std::placeholders::_2, &vs, &SensorImuRate, &user_data.set_acc_bias_seconds));
     resetHorizontalSrv = node->create_service<std_srvs::srv::Trigger>(
       "~/reset_acc_bias", std::bind(reset_horizontal, std::placeholders::_1, std::placeholders::_2, &vs));
+    resetDeviceSrv = node->create_service<std_srvs::srv::Trigger>(
+      "~/reset_device", std::bind(reset_device, std::placeholders::_1, std::placeholders::_2, &vs));
+    tareDeviceSrv = node->create_service<std_srvs::srv::Trigger>(
+      "~/tare_device", std::bind(tare_device, std::placeholders::_1, std::placeholders::_2, &vs));
   }
 
   // You spin me right round, baby

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -538,11 +538,11 @@ int main(int argc, char * argv[])
       "~/set_acc_bias", std::bind(set_horizontal, std::placeholders::_1, std::placeholders::_2, &vs, &SensorImuRate, &user_data.set_acc_bias_seconds));
     resetHorizontalSrv = node->create_service<std_srvs::srv::Trigger>(
       "~/reset_acc_bias", std::bind(reset_horizontal, std::placeholders::_1, std::placeholders::_2, &vs));
-    resetDeviceSrv = node->create_service<std_srvs::srv::Trigger>(
-      "~/reset_device", std::bind(reset_device, std::placeholders::_1, std::placeholders::_2, &vs));
-    tareDeviceSrv = node->create_service<std_srvs::srv::Trigger>(
-      "~/tare_device", std::bind(tare_device, std::placeholders::_1, std::placeholders::_2, &vs));
   }
+  resetDeviceSrv = node->create_service<std_srvs::srv::Trigger>(
+    "~/reset_device", std::bind(reset_device, std::placeholders::_1, std::placeholders::_2, &vs));
+  tareDeviceSrv = node->create_service<std_srvs::srv::Trigger>(
+    "~/tare_device", std::bind(tare_device, std::placeholders::_1, std::placeholders::_2, &vs));
 
   // You spin me right round, baby
   // Right round like a record, baby

--- a/src/vectornav.cpp
+++ b/src/vectornav.cpp
@@ -163,6 +163,28 @@ void Vectornav::reset_acc_bias(
   RCLCPP_INFO(get_logger(), "Done.");
 }
 
+void Vectornav::reset_device(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp)
+{
+  RCLCPP_INFO(get_logger(), "Reset device callback received. Resetting device.");
+  vs_.reset();
+  resp->message = "Device reset command sent. Please, wait for device to reboot.";
+  resp->success = true;
+  RCLCPP_INFO(get_logger(), "Done.");
+}
+
+void Vectornav::tare_device(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp)
+{
+  RCLCPP_INFO(get_logger(), "Tare device callback received. Taring device.");
+  vs_.tare();
+  resp->message = "Device tare command sent. Current readings zeroed.";
+  resp->success = true;
+  RCLCPP_INFO(get_logger(), "Done.");
+}
+
 void Vectornav::advertise_services()
 {
   if (params_.acc_bias_enable) {
@@ -171,6 +193,10 @@ void Vectornav::advertise_services()
     srv_set_acc_bias_ = create_service<std_srvs::srv::Trigger>(
       "~/set_acc_bias", std::bind(&Vectornav::set_acc_bias, this, std::placeholders::_1, std::placeholders::_2));
   }
+  srv_reset_device_ = create_service<std_srvs::srv::Trigger>(
+    "~/reset_device", std::bind(&Vectornav::reset_device, this, std::placeholders::_1, std::placeholders::_2));
+  srv_tare_device_ = create_service<std_srvs::srv::Trigger>(
+    "~/tare_device", std::bind(&Vectornav::tare_device, this, std::placeholders::_1, std::placeholders::_2));
   // Filter unnecessary services (not supported by VN-100)
   if (device_family_ != vn::sensors::VnSensor::Family::VnSensor_Family_Vn100) {
     srv_reset_odom_ = create_service<std_srvs::srv::Empty>(

--- a/src/vectornav_lifecycle.cpp
+++ b/src/vectornav_lifecycle.cpp
@@ -153,6 +153,10 @@ void VectornavLifecycleNode::advertise_services()
     srv_set_acc_bias_ = create_service<std_srvs::srv::Trigger>(
       "~/set_acc_bias", std::bind(&VectornavLifecycleNode::set_acc_bias, this, std::placeholders::_1, std::placeholders::_2));
   }
+  srv_reset_device_ = create_service<std_srvs::srv::Trigger>(
+    "~/reset_device", std::bind(&VectornavLifecycleNode::reset_device, this, std::placeholders::_1, std::placeholders::_2));
+  srv_tare_device_ = create_service<std_srvs::srv::Trigger>(
+    "~/tare_device", std::bind(&VectornavLifecycleNode::tare_device, this, std::placeholders::_1, std::placeholders::_2));
   // Filter unnecessary services (not supported by VN-100)
   if (device_family_ != vn::sensors::VnSensor::Family::VnSensor_Family_Vn100) {
     srv_reset_odom_ = create_service<std_srvs::srv::Empty>(
@@ -246,6 +250,28 @@ void VectornavLifecycleNode::set_acc_bias(
     vs_->writeSettings(true);
     RCLCPP_INFO(get_logger(), "Done.");
   }
+}
+
+void VectornavLifecycleNode::reset_device(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp)
+{
+  RCLCPP_INFO(get_logger(), "Reset device callback received. Resetting device.");
+  vs_->reset();
+  resp->message = "Device reset.";
+  resp->success = true;
+  RCLCPP_INFO(get_logger(), "Done.");
+}
+
+void VectornavLifecycleNode::tare_device(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> resp)
+{
+  RCLCPP_INFO(get_logger(), "Tare device callback received. Taring device.");
+  vs_->tare();
+  resp->message = "Device tared.";
+  resp->success = true;
+  RCLCPP_INFO(get_logger(), "Done.");
 }
 
 void VectornavLifecycleNode::reset_odometry(


### PR DESCRIPTION
This pull request adds two new ROS2 service interfaces to the main node for device management: resetting and taring the VectorNav device. These services allow external nodes or users to remotely issue device reset and tare commands, improving operational flexibility and maintainability.

**New device management services:**

* Added `resetDeviceSrv` and `tareDeviceSrv` as new `Trigger`-type services for device reset and tare operations in the service declarations.
* Implemented the `reset_device` and `tare_device` service handler functions, which respectively call the `reset()` and `tare()` methods on the `VnSensor` object and respond with appropriate success messages.
* Registered the new services in `main()` using `node->create_service`, binding them to the new handler functions.